### PR TITLE
Add subcommand: `blacklist lib`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,6 @@ Clone the repo,
         
 then install the script with [babashka/bbin][babashka-bbin].
 
-    bbin install .
-
-or choose a different local binary name, if you prefer.
-
     bbin install . --as neil-quickadd-dev
 
 [babashka-bbin]: https://github.com/babashka/bbin

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Add the dependencies you usually use in seconds!
 
 ## Installing
 
+0. Install Babashka: https://github.com/babashka/babashka
 1. Install Neil: https://github.com/babashka/neil
 2. Install fzf: https://github.com/junegunn/fzf
 3. Install bbin: https://github.com/babashka/bbin

--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ then install the script with [babashka/bbin][babashka-bbin].
 
 [babashka-bbin]: https://github.com/babashka/bbin
 
-## Usage from Emacs
-
-From Doom Emacs:
+## Doom Emacs usage
 
 ```emacs-lisp
 ;; packages.el

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ then install the script with [babashka/bbin][babashka-bbin].
 
     bbin install .
 
+or choose a different local binary name, if you prefer.
+
+    bbin install . --as neil-quickadd-dev
+
 [babashka-bbin]: https://github.com/babashka/bbin
 
 ## Usage from Emacs

--- a/src/teodorlu/neil_quickadd.clj
+++ b/src/teodorlu/neil_quickadd.clj
@@ -100,6 +100,17 @@ Deletes the index of scanned libraries.
   (fs/delete-if-exists (index-file-path))
   nil)
 
+(defn quickadd-blacklist-lib [{:keys [opts]}]
+  (when (or (:h opts) (:help opts))
+    (println (str/trim "
+Usage: neil-quicadd blacklist-lib
+
+Select a library to be added to the blacklist. Blacklisted libaries are ignored
+when running neil-quickadd.
+"))
+    (System/exit 0))
+  (println 'quickadd-blacklist-index))
+
 (declare print-subcommands)
 
 (defn ^:private neil-dep-versions [lib]
@@ -151,11 +162,12 @@ Usage: neil-quickadd [COMMAND] [OPT...]
 
 Available commands:
 
-  neil-quickadd clear-index  ; Remove the index
-  neil-quickadd help         ; Print subcommands
-  neil-quickadd libs         ; Show the index
-  neil-quickadd scan         ; Scan a folder for dependencies
-  neil-quickadd              ; Add a dependency from the index with FZF
+  neil-quickadd                ; Add a dependency from the index with FZF
+  neil-quickadd blacklist-lib  ; Select a library for blacklisting
+  neil-quickadd clear-index    ; Remove the index
+  neil-quickadd help           ; Print subcommands
+  neil-quickadd libs           ; Show the index
+  neil-quickadd scan           ; Scan a folder for dependencies
 
 Available options:
 
@@ -163,11 +175,12 @@ Available options:
 ")))
 
 (def dispatch-table
-  [{:cmds ["clear-index"] :fn quickadd-clear-index}
-   {:cmds ["help"]        :fn print-subcommands }
-   {:cmds ["libs"]        :fn quickadd-libs     }
-   {:cmds ["scan"]        :fn quickadd-scan      :args->opts [:path]}
-   {:cmds []              :fn quickadd          }])
+  [{:cmds ["clear-index"]   :fn quickadd-clear-index}
+   {:cmds ["help"]          :fn print-subcommands }
+   {:cmds ["libs"]          :fn quickadd-libs     }
+   {:cmds ["scan"]          :fn quickadd-scan      :args->opts [:path]}
+   {:cmds ["blacklist-lib"] :fn quickadd-blacklist-lib}
+   {:cmds []                :fn quickadd          }])
 
 (defn ensure-env-ok
   "Terminate and give user error if the user needs to install something."

--- a/src/teodorlu/neil_quickadd.clj
+++ b/src/teodorlu/neil_quickadd.clj
@@ -92,8 +92,8 @@ Allowed OPTS:
     (update-index! root-dir (fn [_] all-deps))))
 
 (defn quickadd-libs* []
-  (when-let [libs (seq (apply concat (vals (safely-slurp-edn (index-file-path) {}))))]
-    (sort (into #{} libs))))
+  (when-let [libs (into #{} (seq (apply concat (vals (safely-slurp-edn (index-file-path) {})))))]
+    (sort libs)))
 
 (defn quickadd-libs [{:keys [opts]}]
   (when (or (:h opts) (:help opts))

--- a/src/teodorlu/neil_quickadd.clj
+++ b/src/teodorlu/neil_quickadd.clj
@@ -134,8 +134,8 @@ Select a library to be added to the blacklist. Blacklisted libaries are ignored
 when running neil-quickadd.
 "))
     (System/exit 0))
-  (if-let [libs (quickadd-libs*)]
-    (loop []
+  (loop []
+    (if-let [libs (quickadd-libs*)]
       (let [fzf-result (process/shell {:out :string :in (str/join "\n" (into [":quit"] libs))} "fzf")]
         (when (not= 0 (:exit fzf-result))
           ;; If FZF terminates, we terminate.
@@ -147,18 +147,10 @@ when running neil-quickadd.
 
           ;; FIXME
           (blacklist-add! (symbol selected))
-          (recur)
-
-          #_
-          (do
-            (prn ["neil" "dep" "add" selected])
-            (neil-dep-add selected)
-            (recur))
-          )))
-    (do (println "No libs indexed")
-        (println "Please use `neil-quickadd scan` to populate the index")
-        (System/exit 1)))
-  (println 'quickadd-blacklist-index))
+          (recur)))
+      (do (println "No libs indexed")
+          (println "Please use `neil-quickadd scan` to populate the index")
+          (System/exit 1)))))
 
 (declare print-subcommands)
 


### PR DESCRIPTION
`neil-quickadd` now supports blacklisting libraries.

To blacklist a library:

    $ neil-quickadd blacklist-add

Blacklisted libraries are ignored when adding libraries with `neil-quickadd`.